### PR TITLE
Fix: Adjust link attribute

### DIFF
--- a/api_home.yml
+++ b/api_home.yml
@@ -137,8 +137,7 @@ components:
       type: object
       properties:
         title:
-          type: string
-          example: Events
+          $ref: 'schemas/attributes.yml#/components/schemas/attributes/Title'
         link:
           $ref: 'schemas/attributes.yml#/components/schemas/attributes/Link'
         events:

--- a/schemas/attributes.yml
+++ b/schemas/attributes.yml
@@ -32,9 +32,24 @@ components:
         example: "Page Title"
 
       Link:
-        type: string
-        format: uri
-        example: https://www.linkedin.com
+        type: object
+        required:
+          - uri
+          - label
+        additionalProperties: false
+        properties:
+          label:
+            type: string
+            maxLength: 30
+            pattern: '^[A-Za-z\s]+$'
+            example: 'Send us a report on Github'
+          uri:
+            type: string
+            format: uri
+            example: 'https://github.com/Women-Coding-Community/wcc-frontend/issues'
+          title:
+            $ref: '#/components/schemas/attributes/Title'
+            example: Experience Technical Issues?
 
       Links:
         type: array


### PR DESCRIPTION
* Include missing attributes for Link (Label, URI, Title), in many cases we need the link description and the label in case it is not the same as the URI. 
```
"link": {
          "label": "Send us a report on Github",
          "uri": "https://github.com/Women-Coding-Community/wcc-frontend/issues",
          "title": "Page Title"
        }
```

* re-used title attribute.

**Announcements Section**
<img width="1112" alt="image" src="https://github.com/Women-Coding-Community/wcc-api/assets/3664747/4a0856b9-c721-46be-ab7c-d827caf07faa">
