### PR TITLE
feat: Include Full Banner Section in Home page

### DIFF
--- a/api_home.yml
+++ b/api_home.yml
@@ -52,6 +52,8 @@ components:
       properties:
         heroSection:
           $ref: '#/components/schemas/HeroSection'
+        fullBannerSection:
+          $ref: '#/components/schemas/FullBannerSection'
         programmesSection:
           $ref: '#/components/schemas/ProgrammesSection'
         announcementSection:
@@ -72,6 +74,21 @@ components:
           example: Empowering Women in Their Tech Careers
         images:
           $ref: 'schemas/attributes.yml#/components/schemas/attributes/Images'
+
+    FullBannerSection:
+      type: object
+      properties:
+        title:
+          type: string
+          example: Become a Mentor
+        description:
+          type: string
+          example: |
+            Ready to empower and be empowered in tech? Become a mentor! Expand your network, give back, share expertise, and discover new perspectives.
+        images:
+          $ref: 'schemas/attributes.yml#/components/schemas/attributes/Images'
+        link:
+          $ref: 'schemas/attributes.yml#/components/schemas/attributes/Link'
 
     ProgrammesSection:
       type: object


### PR DESCRIPTION
This section was not included in the previous home api content, and it is part of the definition. 

<img width="1528" alt="image" src="https://github.com/Women-Coding-Community/wcc-api/assets/3664747/e4403daa-97f4-44d2-a46d-7b9726001a28">

```
 "fullBannerSection": {
    "title": "Become a Mentor",
    "description": "Ready to empower and be empowered in tech? Become a mentor! Expand your network, give back, share expertise, and discover new perspectives.\n",
    "images": [
      {
        "path": "https://cloudprovider.com/image.png",
        "alt": "There are two women talking during a productive mentoring session",
        "type": "desktop"
      },
      {
        "path": "https://cloudprovider.com/mobile.png",
        "alt": "There are two women talking during a productive mentoring session",
        "type": "mobile"
      }
    ],
    "link": "/mentorship/mentors"
  }
```